### PR TITLE
Update AssemblyScript syntax

### DIFF
--- a/blank_project/assembly/main.ts
+++ b/blank_project/assembly/main.ts
@@ -9,7 +9,7 @@ import { Greeter } from "./model.near";
 // using `export` keyword.
 
 export function hello(): string {
-  let greeter = new Greeter("hello");
+  let greeter = new Greeter("Hello");
   return greeter.greet("world");
 }
 // << hello-snippet


### PR DESCRIPTION
Update assemblyscript syntax after the runtime change. Requires https://github.com/nearprotocol/assemblyscript/pull/36, https://github.com/nearprotocol/near-runtime-ts/pull/27, and https://github.com/nearprotocol/assemblyscript-json/pull/13.