### PR TITLE
Add out dir to blank project with gitignore

### DIFF
--- a/blank_project/out/.gitignore
+++ b/blank_project/out/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore


### PR DESCRIPTION
This is so that we don't need to create this dir on build + fix for https://github.com/nearprotocol/near-shell/issues/36