### PR TITLE
added mkdirp to gulp utils

### DIFF
--- a/blank_project/package.json
+++ b/blank_project/package.json
@@ -3,7 +3,7 @@
   "description": "",
   "version": "0.0.1",
   "scripts": {
-    "build": "mkdir -p out/ && gulp",
+    "build": "gulp",
     "deploy:contract": "near deploy",
     "deploy:pages": "gh-pages -d src",
     "deploy": "npm run build && npm run deploy:contract && npm run deploy:pages",
@@ -12,13 +12,12 @@
     "test": "npm run build && jest test --env=near-shell/test_environment"
   },
   "devDependencies": {
-    "assemblyscript-json": "github:nearprotocol/assemblyscript-json#staging",
-    "bignum": "github:MaxGraey/bignum.wasm",
     "gh-pages": "^2.1.1",
     "gulp": "^4.0.2",
     "jest": "^24.8.0",
     "jest-environment-node": "^24.8.0",
-    "near-shell": "github:nearprotocol/near-shell#staging"
+    "near-runtime-ts": "github:nearprotocol/near-runtime-ts#staging",
+    "near-shell": "file:.."
   },
   "wasmStudio": {
     "name": "Hello World Example",

--- a/gulp-utils.js
+++ b/gulp-utils.js
@@ -1,13 +1,3 @@
-// FUTURE PEOPLE: This file is called "gulp-utils" but it's not related to the deprecated library called "gulp-utils". Don't panic.
-// function generateBindings(inputFile, outputFile, callback) {
-//   const asc = getAsc();
-//   asc.main([
-//     inputFile,
-//     "--baseDir", process.cwd(),
-//     "--nearFile", outputFile,
-//     "--measure"
-//   ], callback);
-// }
 var path = require("path");
 
 function compile(inputFile, outputFile, callback) {
@@ -31,9 +21,25 @@ function getAsc() {
   }
 
   asc = require("assemblyscript/bin/asc");
-
+  
   const fs = require("fs");
   const pathModule = require("path");
+
+  // Create parent directories if they don't exist
+  function mkdirp(path){
+    let dirname = pathModule.dirname(path);
+    let paths = []
+    while (!fs.existsSync(dirname)){
+      paths.unshift(pathModule.basename(dirname));
+      dirname = pathModule.dirname(dirname);
+    }
+    if (paths.length > 0){
+      for (const i in paths){
+        fs.mkdirSync(pathModule.join(dirname, ...paths.slice(0,i + 1)))
+      }
+    }
+  }
+
   asc.main = (main => (args, options, fn) => {
     if (typeof options === "function") {
       fn = options;
@@ -45,22 +51,28 @@ function getAsc() {
       stdout: process.stdout || asc.createMemoryStream(logLn),
       stderr: process.stderr || asc.createMemoryStream(logLn),
       readFile: (filename, baseDir) => {
-        baseDir = pathModule.relative(process.cwd(), baseDir);
         let path = pathModule.join(baseDir, filename);
         if (!fs.existsSync(path)) {
             return null;
         }
-
         return fs.readFileSync(path).toString("utf8");
       },
       writeFile: (filename, contents) => {
         const name = filename.startsWith("../") ? filename.substring(3) : filename;
+        mkdirp(name);
         fs.writeFileSync(name, contents);
       },
-      listFiles: () => []
+      listFiles: (dirname, baseDir) => {
+        try {
+          return fs.readdirSync(path.join(baseDir, dirname)).filter(file => /^(?!.*\.d\.ts$).*\.ts$/.test(file));
+        } catch (e) {
+          return null;
+        }
+      }
     }, fn);
   })(asc.main);
   return asc;
 }
+
 
 module.exports = { compile };


### PR DESCRIPTION
- write file now creates directories that don't exist in the path of a new file.

Also blank_project now imports the root project directory.  Otherwise it can't test the new feature.

fixes #121 