### PR TITLE
Remove confusing "failed to load validator key" warning.

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,15 +41,11 @@ exports.clean = async function() {
 };
 
 async function connect(options) {
-    if (options.keyPath === undefined && options.helperUrl === undefined) {
-        const homeDir = options.homeDir || `${process.env.HOME}/.near`;
-        options.keyPath = `${homeDir}/validator_key.json`;
-    }
-    // TODO: search for key store.
     const keyStore = new UnencryptedFileSystemKeyStore('./neardev');
     options.deps = {
         keyStore,
     };
+    // TODO: search for key store.
     return await nearjs.connect(options);
 }
 


### PR DESCRIPTION
This happens because we try to load the validator key for all environments