### PR TITLE
Fix mkdirp

### DIFF
--- a/blank_project/package.json
+++ b/blank_project/package.json
@@ -12,8 +12,6 @@
     "test": "npm run build && jest test --env=near-shell/test_environment"
   },
   "devDependencies": {
-    "assemblyscript-json": "github:nearprotocol/assemblyscript-json",
-    "bignum": "github:MaxGraey/bignum.wasm",
     "gh-pages": "^2.1.1",
     "gulp": "^4.0.2",
     "jest": "^24.8.0",

--- a/gulp-utils.js
+++ b/gulp-utils.js
@@ -60,10 +60,15 @@ function getAsc() {
       },
       writeFile: (filename, contents) => {
         const name = filename.startsWith("../") ? filename.substring(3) : filename;
-        mkdirp(name);
+        if (fs.mkdirSync){
+          mkdirp(name);
+        }
         fs.writeFileSync(name, contents);
       },
       listFiles: (dirname, baseDir) => {
+        if (fs.readdirSync == undefined){
+          return [];
+        }
         baseDir = pathModule.relative(process.cwd(), baseDir);
         try {
           return fs.readdirSync(path.join(baseDir, dirname)).filter(file => /^(?!.*\.d\.ts$).*\.ts$/.test(file));

--- a/gulp-utils.js
+++ b/gulp-utils.js
@@ -64,6 +64,7 @@ function getAsc() {
         fs.writeFileSync(name, contents);
       },
       listFiles: (dirname, baseDir) => {
+        baseDir = pathModule.relative(process.cwd(), baseDir);
         try {
           return fs.readdirSync(path.join(baseDir, dirname)).filter(file => /^(?!.*\.d\.ts$).*\.ts$/.test(file));
         } catch (e) {

--- a/gulp-utils.js
+++ b/gulp-utils.js
@@ -1,13 +1,3 @@
-// FUTURE PEOPLE: This file is called "gulp-utils" but it's not related to the deprecated library called "gulp-utils". Don't panic.
-// function generateBindings(inputFile, outputFile, callback) {
-//   const asc = getAsc();
-//   asc.main([
-//     inputFile,
-//     "--baseDir", process.cwd(),
-//     "--nearFile", outputFile,
-//     "--measure"
-//   ], callback);
-// }
 var path = require("path");
 
 function compile(inputFile, outputFile, callback) {
@@ -31,9 +21,25 @@ function getAsc() {
   }
 
   asc = require("assemblyscript/bin/asc");
-
+  
   const fs = require("fs");
   const pathModule = require("path");
+
+  // Create parent directories if they don't exist
+  function mkdirp(path){
+    let dirname = pathModule.dirname(path);
+    let paths = [];
+    while (!fs.existsSync(dirname)){
+      paths.unshift(pathModule.basename(dirname));
+      dirname = pathModule.dirname(dirname);
+    }
+    if (paths.length > 0){
+      for (const i in paths){
+        fs.mkdirSync(pathModule.join(dirname, ...paths.slice(0,i + 1)))
+      }
+    }
+  }
+
   asc.main = (main => (args, options, fn) => {
     if (typeof options === "function") {
       fn = options;
@@ -50,17 +56,24 @@ function getAsc() {
         if (!fs.existsSync(path)) {
             return null;
         }
-
         return fs.readFileSync(path).toString("utf8");
       },
       writeFile: (filename, contents) => {
         const name = filename.startsWith("../") ? filename.substring(3) : filename;
+        mkdirp(name);
         fs.writeFileSync(name, contents);
       },
-      listFiles: () => []
+      listFiles: (dirname, baseDir) => {
+        try {
+          return fs.readdirSync(path.join(baseDir, dirname)).filter(file => /^(?!.*\.d\.ts$).*\.ts$/.test(file));
+        } catch (e) {
+          return null;
+        }
+      }
     }, fn);
   })(asc.main);
   return asc;
 }
+
 
 module.exports = { compile };


### PR DESCRIPTION
- Add fs methods check so that it has default behavior in NEARStudio, since the write file function handles mkdirp