### PR TITLE
add version check (after any command) fixes #183

### DIFF
--- a/bin/near-cli.js
+++ b/bin/near-cli.js
@@ -174,6 +174,7 @@ const clean = {
 
 let config = require('../get-config')();
 yargs // eslint-disable-line
+    .middleware(require('../utils/check-version'))
     .scriptName('near')
     .option('nodeUrl', {
         desc: 'NEAR node URL',

--- a/package.json
+++ b/package.json
@@ -31,11 +31,14 @@
   },
   "dependencies": {
     "bs58": "^4.0.1",
+    "chalk": "^3.0.0",
+    "is-ci": "^2.0.0",
     "jest-environment-node": "^24.5.0",
     "ncp": "^2.0.0",
     "near-assemblyscript": "^0.7.4",
     "nearlib": "^0.17.1",
     "rimraf": "^3.0.0",
+    "update-notifier": "^3.0.1",
     "yargs": "^15.0.1"
   },
   "keywords": [

--- a/utils/check-version.js
+++ b/utils/check-version.js
@@ -8,13 +8,7 @@ const chalk = require('chalk');  // colorize output
 const isCI = require('is-ci');   // avoid output if running in CI server
 
 // updateCheckInterval is measured in seconds
-const ONCE_PER = {
-    SECOND: 0,
-    MINUTE: 1000 * 60,
-    HOUR:   1000 * 60 * 60,
-    DAY:    1000 * 60 * 60 * 24,
-    WEEK:   1000 * 60 * 60 * 24 * 7
-};
+const UPDATE_CHECK_INTERVAL_SECONDS = 1;
 
 /**
     check the current version of NEAR Shell against latest as published on npm
@@ -22,7 +16,7 @@ const ONCE_PER = {
 module.exports = async function checkVersion() {
     const pkg = require('../package.json');
 
-    const notifier = updateNotifier({ pkg, updateCheckInterval: ONCE_PER.SECOND });
+    const notifier = updateNotifier({ pkg, updateCheckInterval: UPDATE_CHECK_INTERVAL_SECONDS });
 
     if (
         notifier.update &&

--- a/utils/check-version.js
+++ b/utils/check-version.js
@@ -1,0 +1,75 @@
+/**
+    this utility inspired by:
+    https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli
+    https://github.com/npm/cli
+ */
+const updateNotifier = require('update-notifier');
+const chalk = require('chalk');  // colorize output
+const isCI = require('is-ci');   // avoid output if running in CI server
+
+// updateCheckInterval is measured in seconds
+const ONCE_PER = {
+    SECOND: 0,
+    MINUTE: 1000 * 60,
+    HOUR:   1000 * 60 * 60,
+    DAY:    1000 * 60 * 60 * 24,
+    WEEK:   1000 * 60 * 60 * 24 * 7
+};
+
+/**
+    check the current version of NEAR Shell against latest as published on npm
+ */
+module.exports = async function checkVersion() {
+    const pkg = require('../package.json');
+
+    const notifier = updateNotifier({ pkg, updateCheckInterval: ONCE_PER.SECOND });
+
+    if (
+        notifier.update &&
+        notifier.update.latest !== pkg.version &&
+        !isCI
+    ) {
+        const { type: diff, current, latest } = notifier.update;
+        const update = normalizePhrasingOf(diff);
+        const message = chalk`NEAR Shell has a ${update} available {dim ${current}} → {green ${latest}}
+Run {cyan npm update -g near-shell} to avoid unexpected behavior`;
+
+        const boxenOpts = {
+            padding: 1,
+            margin: 1,
+            align: 'left',
+            borderColor: 'yellow',
+            borderStyle: 'round'
+        };
+
+        notifier.notify({ message, boxenOpts });
+    }
+};
+
+
+/**
+    semver-diff always returns undefined or 1 word
+    but this doesn't read well in English ouput
+
+    see: https://www.npmjs.com/package/semver-diff
+ */
+function normalizePhrasingOf(text) {
+    let update = 'new version'; // new version available
+
+    switch (text) {
+    case 'major': // major update available
+    case 'minor': // minor update available
+        update = `${text} update`;
+        break;
+    case 'patch':
+        update = text; // patch available
+        break;
+    case 'build':
+        update = `new ${text}`; // new build available
+        break;
+    default: // [ prepatch | premajor | preminor | prerelease ] available
+        update = text;
+    }
+
+    return update;
+}


### PR DESCRIPTION
added update-notifier with cleaner messages for the user.  this requires to the user actually attempt to issue a command.  given current config of yargs it *does not always* print out the need for an upgrade, only when a command is added.

note also, **i didn't add any tests for this**

maybe these links will help with follow up

testing `yargs` output
https://github.com/yargs/yargs/blob/master/docs/advanced.md#testing-a-command-module

(offtopic) also consider using nave for testing against node versions
https://github.com/isaacs/nave