### PR TITLE
cli tells user keys are in ./neardev instead of ~/.near

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,6 @@ near <command>
 | --networkId               | NEAR network ID for different keys by network | [string]  |"default"              |
 | --helperUrl               | NEAR contract helper URL                      | [string]  |                       |
 | --keyPath                 | Path to master account key                    | [string]  |                       |
-| --homeDir                 | Where to look for master account              | [string]  |"~/.near"              |
 | --accountId               | Unique identifier for the account             | [string]  [required]|             |
 | --masterAccount           | Account used to create requested account.     | [string]  [required]|             |
 | --publicKey               | Public key to initialize the account with     | [string]  [required]|             |

--- a/bin/near-cli.js
+++ b/bin/near-cli.js
@@ -165,11 +165,6 @@ yargs // eslint-disable-line
         desc: 'Path to master account key',
         type: 'string',
     })
-    .option('homeDir', {
-        desc: 'Where to look for master account, default is ./neardev',
-        type: 'string',
-        default: `${process.cwd()}/neardev`,
-    })
     .option('accountId', {
         desc: 'Unique identifier for the account',
         type: 'string',

--- a/bin/near-cli.js
+++ b/bin/near-cli.js
@@ -166,9 +166,9 @@ yargs // eslint-disable-line
         type: 'string',
     })
     .option('homeDir', {
-        desc: 'Where to look for master account, default is ~/.near',
+        desc: 'Where to look for master account, default is ./neardev',
         type: 'string',
-        default: `${process.env.HOME}/.near`,
+        default: `${process.cwd()}/neardev`,
     })
     .option('accountId', {
         desc: 'Unique identifier for the account',


### PR DESCRIPTION
As I understand, `near-core` places validator keys in `~/.near` but shell looks for keys in the project's `./neardev` directory.
https://github.com/nearprotocol/near-shell/blob/master/middleware/key-store.js#L7

With this PR, if a user types `near --help` they will see cli messages explaining this.

<img width="1006" alt="Screenshot 2020-01-23 20 00 18" src="https://user-images.githubusercontent.com/1042667/73043675-14aad300-3e1b-11ea-9ce7-728218898f50.png">

Smallest pull request in my life. 🎊 