### PR TITLE
Clarity on yoctonear #258

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 tmp-project
 neardev/*
 package-lock.json
+.idea

--- a/commands/call.js
+++ b/commands/call.js
@@ -23,7 +23,7 @@ module.exports = {
 
 async function scheduleFunctionCall(options) {
     console.log(`Scheduling a call: ${options.contractName}.${options.methodName}(${options.args || ''})` +
-        (options.amount && options.amount != '0' ? ` with attached ${utils.format.parseNearAmount(options.amount)} NEAR` : ''));
+        (options.amount && options.amount != '0' ? ` with attached ${options.amount} NEAR (${utils.format.parseNearAmount(options.amount)} yoctoNEAR)` : ''));
     const near = await connect(options);
     const account = await near.account(options.accountId);
     const functionCallResponse = await account.functionCall(

--- a/commands/call.js
+++ b/commands/call.js
@@ -23,7 +23,7 @@ module.exports = {
 
 async function scheduleFunctionCall(options) {
     console.log(`Scheduling a call: ${options.contractName}.${options.methodName}(${options.args || ''})` +
-        (options.amount && options.amount != '0' ? ` with attached ${options.amount} NEAR (${utils.format.parseNearAmount(options.amount)} yoctoNEAR)` : ''));
+        (options.amount && options.amount != '0' ? ` with attached ${options.amount} NEAR` : ''));
     const near = await connect(options);
     const account = await near.account(options.accountId);
     const functionCallResponse = await account.functionCall(

--- a/index.js
+++ b/index.js
@@ -108,7 +108,7 @@ exports.keys = async function(options) {
 };
 
 exports.sendMoney = async function(options) {
-    console.log(`Sending ${options.amount} (${utils.format.parseNearAmount(options.amount)}) NEAR to ${options.receiver} from ${options.sender}`);
+    console.log(`Sending ${options.amount} NEAR (${utils.format.parseNearAmount(options.amount)} yoctoNEAR) to ${options.receiver} from ${options.sender}`);
     const near = await connect(options);
     const account = await near.account(options.sender);
     console.log(inspectResponse(await account.sendMoney(options.receiver, utils.format.parseNearAmount(options.amount))));

--- a/index.js
+++ b/index.js
@@ -108,7 +108,7 @@ exports.keys = async function(options) {
 };
 
 exports.sendMoney = async function(options) {
-    console.log(`Sending ${options.amount} NEAR (${utils.format.parseNearAmount(options.amount)} yoctoNEAR) to ${options.receiver} from ${options.sender}`);
+    console.log(`Sending ${options.amount} NEAR to ${options.receiver} from ${options.sender}`);
     const near = await connect(options);
     const account = await near.account(options.sender);
     console.log(inspectResponse(await account.sendMoney(options.receiver, utils.format.parseNearAmount(options.amount))));


### PR DESCRIPTION
Address issue seen in #258 
Essentially we were calling nearlib's `parseNearAmount` and showing the user that value as if it were NEAR, when in truth it's the yoctoNEAR denomination.
I saw this on `call` and `send` commands.
Now:
<img width="788" alt="Screenshot 2020-02-03 10 09 31" src="https://user-images.githubusercontent.com/1042667/73655966-e70d2780-466d-11ea-8004-2879c817e174.png">
<img width="575" alt="Screenshot 2020-02-03 10 10 18" src="https://user-images.githubusercontent.com/1042667/73655969-ea081800-466d-11ea-9e8b-f6d2ea47ab42.png">
