### PR TITLE
Add Yargs default and middleware logic to display helpful message during invalid arg/command calls

### DIFF
--- a/bin/near-cli.js
+++ b/bin/near-cli.js
@@ -134,9 +134,31 @@ const deploy = {
 registerCommand(deploy);
 
 const callViewFunction = {
-    command: 'view <contractName> <methodName> [args]',
+    command: 'view [contractName] [methodName] [data] [gas] [amount]',
     desc: 'make smart contract call which can view state',
-    builder: (yargs) => yargs,
+    builder: (yargs) => yargs
+        .option('contractName', {
+            desc: 'Contract where the method is being called',
+            type: 'string',
+        })    
+        .option('methodName', {
+            desc: 'Contract method being called',
+            type: 'string',
+        })
+        .option('data', {
+            desc: 'Data to send to method',
+            type: 'string',
+        })
+        .option('gas', {
+            desc: 'Max amount of gas this call can use',
+            type: 'string',
+            default: '100000000000000'
+        })
+        .option('amount', {
+            desc: 'Number of tokens to attach',
+            type: 'string',
+            default: '0'
+        }),        
     handler: exitOnError(main.callViewFunction)
 };
 registerCommand(callViewFunction);
@@ -223,8 +245,13 @@ yargs // eslint-disable-line
         desc: 'Unique identifier for the account',
         type: 'string',
     })
-    .middleware(require('../middleware/key-store'));
-    .middleware(require('../middleware/print-options'))
+    .option('masterAccount', {
+        desc: 'Master account used when create new accounts',
+        type: 'string',
+        hidden: true
+    })
+    .middleware(require('../middleware/key-store'))
+    .middleware(require('../middleware/print-options'));
 
 for (const command of registeredCommandObjs) {
     yargs.command(command);

--- a/bin/near-cli.js
+++ b/bin/near-cli.js
@@ -146,7 +146,7 @@ const clean = {
 const defaultCommand = {
     command: '$0',
     handler: exitOnError(main.defaultCommand)
-}
+};
 
 let config = require('../get-config')();
 yargs // eslint-disable-line

--- a/bin/near-cli.js
+++ b/bin/near-cli.js
@@ -2,24 +2,24 @@ const yargs = require('yargs');
 const main = require('../');
 const exitOnError = require('../utils/exit-on-error');
 
-let registeredCommands = []
-let registeredCommandObjs = []
+let registeredCommands = [];
+let registeredCommandObjs = [];
 
 function registerCommand(cmd) {
-  registeredCommandObjs.push(cmd)
-  if (cmd.hasOwnProperty('command')) {
-    // remove […] and <…> and trim, leaving only the command (ex: 'state')
-    // check for aliases
-    const cleanCommand = (cmd) => cmd.replace(/\s*\[.*\]/gi, '').replace(/\s*<.*>/gi, '').trim()
-    if (Array.isArray(cmd.command)) {
-      for (const alias of cmd.command) {
-        console.log('findthis', alias)
-        registeredCommands.push(cleanCommand(alias))
-      }
-    } else {
-      registeredCommands.push(cleanCommand(cmd.command))
+    registeredCommandObjs.push(cmd);
+    if (Object.prototype.hasOwnProperty.call(cmd, 'command')) {
+        // remove […] and <…> and trim, leaving only the command (ex: 'state')
+        // check for aliases
+        const cleanCommand = (cmd) => cmd.replace(/\s*\[.*\]/gi, '').replace(/\s*<.*>/gi, '').trim();
+        if (Array.isArray(cmd.command)) {
+            for (const alias of cmd.command) {
+                console.log('findthis', alias);
+                registeredCommands.push(cleanCommand(alias));
+            }
+        } else {
+            registeredCommands.push(cleanCommand(cmd.command));
+        }
     }
-  }
 }
 
 // For account:
@@ -34,7 +34,7 @@ const login = {
         }),
     handler: exitOnError(main.login)
 };
-registerCommand(login)
+registerCommand(login);
 
 const viewAccount = {
     command: 'state <accountId>',
@@ -47,7 +47,7 @@ const viewAccount = {
         }),
     handler: exitOnError(main.viewAccount)
 };
-registerCommand(viewAccount)
+registerCommand(viewAccount);
 
 const deleteAccount = {
     command: 'delete <accountId> <beneficiaryId>',
@@ -65,7 +65,7 @@ const deleteAccount = {
         }),
     handler: exitOnError(main.deleteAccount)
 };
-registerCommand(deleteAccount)
+registerCommand(deleteAccount);
 
 const keys = {
     command: 'keys <accountId>',
@@ -78,7 +78,7 @@ const keys = {
         }),
     handler: exitOnError(main.keys)
 };
-registerCommand(keys)
+registerCommand(keys);
 
 const sendMoney = {
     command: 'send <sender> <receiver> <amount>',
@@ -90,7 +90,7 @@ const sendMoney = {
         }),
     handler: exitOnError(main.sendMoney)
 };
-registerCommand(sendMoney)
+registerCommand(sendMoney);
 
 const stake = {
     command: 'stake [accountId] [stakingKey] [amount]',
@@ -113,7 +113,7 @@ const stake = {
         }),
     handler: exitOnError(main.stake)
 };
-registerCommand(stake)
+registerCommand(stake);
 
 // For contract:
 const deploy = {
@@ -130,7 +130,7 @@ const deploy = {
         }),
     handler: exitOnError(main.deploy)
 };
-registerCommand(deploy)
+registerCommand(deploy);
 
 const callViewFunction = {
     command: 'view <contractName> <methodName> [args]',
@@ -138,7 +138,7 @@ const callViewFunction = {
     builder: (yargs) => yargs,
     handler: exitOnError(main.callViewFunction)
 };
-registerCommand(callViewFunction)
+registerCommand(callViewFunction);
 
 const { spawn } = require('child_process');
 const build = {
@@ -157,7 +157,7 @@ const build = {
         });
     }
 };
-registerCommand(build)
+registerCommand(build);
 
 const clean = {
     command: 'clean',
@@ -170,31 +170,31 @@ const clean = {
         }),
     handler: exitOnError(main.clean)
 };
-registerCommand(clean)
+registerCommand(clean);
 
 const defaultCommand = {
     command: '$0',
 };
-registerCommand(defaultCommand)
+registerCommand(defaultCommand);
 
 // middleware to validate commands and arguments
 const checkCommandsArgs = (argv, yargsInstance) => {
-  main.checkCommandsArgs(argv, yargsInstance, registeredCommandObjs, registeredCommands)
-}
+    main.checkCommandsArgs(argv, yargsInstance, registeredCommandObjs, registeredCommands);
+};
 
 // add external commands
-const createAccountCommand = require('../commands/create-account')
-registerCommand(createAccountCommand)
-const txStatusCommand = require('../commands/tx-status')
-registerCommand(txStatusCommand)
-const devDeployCommand = require('../commands/dev-deploy')
-registerCommand(devDeployCommand)
-const callCommand = require('../commands/call')
-registerCommand(callCommand)
-const replCommand = require('../commands/repl')
-registerCommand(replCommand)
-const generateKeyCommand = require('../commands/generate-key')
-registerCommand(generateKeyCommand)
+const createAccountCommand = require('../commands/create-account');
+registerCommand(createAccountCommand);
+const txStatusCommand = require('../commands/tx-status');
+registerCommand(txStatusCommand);
+const devDeployCommand = require('../commands/dev-deploy');
+registerCommand(devDeployCommand);
+const callCommand = require('../commands/call');
+registerCommand(callCommand);
+const replCommand = require('../commands/repl');
+registerCommand(replCommand);
+const generateKeyCommand = require('../commands/generate-key');
+registerCommand(generateKeyCommand);
 
 let config = require('../get-config')();
 yargs // eslint-disable-line
@@ -247,7 +247,7 @@ yargs
     .demandCommand(1, 'Please enter a command')
     .wrap(null)
     .fail(function (msg) {
-      console.error(`Error: ${msg}\nPlease use the --help flag for more information.`)
-      yargs.exit()
+        console.error(`Error: ${msg}\nPlease use the --help flag for more information.`);
+        yargs.exit();
     })
     .argv;

--- a/bin/near-cli.js
+++ b/bin/near-cli.js
@@ -143,6 +143,11 @@ const clean = {
     handler: exitOnError(main.clean)
 };
 
+const defaultCommand = {
+    command: '$0',
+    handler: exitOnError(main.defaultCommand)
+}
+
 let config = require('../get-config')();
 yargs // eslint-disable-line
     .middleware(require('../utils/check-version'))
@@ -191,6 +196,7 @@ yargs // eslint-disable-line
     .command(login)
     .command(require('../commands/repl'))
     .command(require('../commands/generate-key'))
+    .command(defaultCommand)
     .config(config)
     .alias({
         'accountId': ['account_id'],

--- a/bin/near-cli.js
+++ b/bin/near-cli.js
@@ -9,7 +9,16 @@ function registerCommand(cmd) {
   registeredCommandObjs.push(cmd)
   if (cmd.hasOwnProperty('command')) {
     // remove […] and <…> and trim, leaving only the command (ex: 'state')
-    registeredCommands.push(cmd.command.replace(/\s*\[.*\]/gi, '').replace(/\s*<.*>/gi, '').trim())
+    // check for aliases
+    const cleanCommand = (cmd) => cmd.replace(/\s*\[.*\]/gi, '').replace(/\s*<.*>/gi, '').trim()
+    if (Array.isArray(cmd.command)) {
+      for (const alias of cmd.command) {
+        console.log('findthis', alias)
+        registeredCommands.push(cleanCommand(alias))
+      }
+    } else {
+      registeredCommands.push(cleanCommand(cmd.command))
+    }
   }
 }
 

--- a/commands/call.js
+++ b/commands/call.js
@@ -5,9 +5,21 @@ const connect = require('../utils/connect');
 const inspectResponse = require('../utils/inspect-response');
 
 module.exports = {
-    command: 'call <contractName> <methodName> [args]',
+    command: 'call [contractName] [methodName] [data] [gas] [amount]',
     desc: 'schedule smart contract call which can modify state',
     builder: (yargs) => yargs
+        .option('contractName', {
+            desc: 'Contract where the method is being called',
+            type: 'string',
+        })    
+        .option('methodName', {
+            desc: 'Contract method being called',
+            type: 'string',
+        })
+        .option('data', {
+            desc: 'Data to send to method',
+            type: 'string',
+        })        
         .option('gas', {
             desc: 'Max amount of gas this call can use',
             type: 'string',

--- a/index.js
+++ b/index.js
@@ -5,8 +5,7 @@ ncp.limit = 16;
 const rimraf = require('rimraf');
 const readline = require('readline');
 const URL = require('url').URL;
-const stringWidth = require('string-width')
-
+const stringWidth = require('string-width');
 const { KeyPair, utils } = require('nearlib');
 
 const connect = require('./utils/connect');
@@ -126,90 +125,90 @@ exports.stake = async function(options) {
 exports.checkCommandsArgs = async function (argv, yargs, registeredCommandObjs, registeredCommands) {
     // logic borrowed from yargs/lib/usage.js
     function maxWidth (table, theWrap, modifier) {
-        let width = 0
+        let width = 0;
         if (!Array.isArray(table)) {
-          table = Object.keys(table).map(key => [table[key]])
+            table = Object.keys(table).map(key => [table[key]]);
         }
         
         table.forEach((v) => {
-          width = Math.max(
-            stringWidth(modifier ? `${modifier} ${v['command']}` : v['command']),
-            width
-          )
-        })
+            width = Math.max(
+                stringWidth(modifier ? `${modifier} ${v['command']}` : v['command']),
+                width
+            );
+        });
         
-        if (theWrap) width = Math.min(width, parseInt(theWrap * 0.5, 10))
+        if (theWrap) width = Math.min(width, parseInt(theWrap * 0.5, 10));
         
-        return width
+        return width;
     }
 
     // find and inform user of invalid commands
-    const invalidCommands = argv._.filter(command => !registeredCommands.includes(command))
+    const invalidCommands = argv._.filter(command => !registeredCommands.includes(command));
     if (invalidCommands.length === 1) {
-        console.log(`Invalid command '${invalidCommands}'`)
+        console.log(`Invalid command '${invalidCommands}'`);
     } else if (invalidCommands.length > 1) {
-        console.log(`Invalid commands '${invalidCommands.join(', ')}'`)
+        console.log(`Invalid commands '${invalidCommands.join(', ')}'`);
     }
     
     // valid arguments as understood by the yargs instance
-    const activeArgs = Object.keys(argv)
-    const validArgs = Object.keys(yargs.parsed.aliases)
+    const activeArgs = Object.keys(argv);
+    const validArgs = Object.keys(yargs.parsed.aliases);
     // add a handful of special keys for our use case
-    validArgs.push(...['_', '$0', 'keyStore', 'contractName', 'walletUrl'])
+    validArgs.push(...['_', '$0', 'keyStore', 'contractName', 'walletUrl']);
     
-    const invalidArguments = activeArgs.filter(arg => !validArgs.includes(arg))
+    const invalidArguments = activeArgs.filter(arg => !validArgs.includes(arg));
     if (invalidArguments.length === 1) {
-        console.error(`Invalid argument '${invalidArguments[0]}'`)
+        console.error(`Invalid argument '${invalidArguments[0]}'`);
     } else if (invalidArguments.length > 1) {
-        console.error(`Invalid argument(s) '${invalidArguments.join(', ')}'`)
-    }    
-    
+        console.error(`Invalid argument(s) '${invalidArguments.join(', ')}'`);
+    }
+
     // exit yargs, otherwise it tries to continue throwing misleading errors
-    if (invalidArguments.length !== 0 || invalidCommands.length !== 0) yargs.exit()
+    if (invalidArguments.length !== 0 || invalidCommands.length !== 0) yargs.exit();
     
     // command 'near' with no invalid arguments or invalid commands displays --help
     // logic borrowed from yargs/lib/usage.js
-    if (argv.hasOwnProperty('_') && argv._.length === 0 && invalidCommands.length === 0 && invalidArguments.length === 0) {
-      const ui = require('cliui')({
-        width: null,
-        wrap: null
-      })
-      if (registeredCommandObjs.length) {
-        ui.div('Commands:')
-    
-        const context = yargs.getContext()
-        const parentCommands = context.commands.length ? `${context.commands.join(' ')} ` : ''
-    
-        if (yargs.getParserConfiguration()['sort-commands'] === true) {
-          commands = registeredCommandObjs.sort((a, b) => a[0].localeCompare(b[0]))
-        }
-    
-        registeredCommandObjs.forEach((command) => {
-          const commandString = `near ${parentCommands}${command.command.replace(/^\$0 ?/, '')}` // drop $0 from default commands.
-          ui.span(
-            {
-              text: commandString,
-              padding: [0, 2, 0, 2],
-              width: maxWidth(registeredCommandObjs, null, `near${parentCommands}`) + 4
-            },
-            { text: command['desc'] }
-          )
-          const hints = []
-          if (command[2]) hints.push(`[${'default:'.slice(0, -1)}]`) // TODO hacking around i18n here
-          if (command[3] && command[3].length) {
-            hints.push(`[${'aliases:'} ${command[3].join(', ')}]`)
-          }
-          if (hints.length) {
-            ui.div({ text: hints.join(' '), padding: [0, 0, 0, 2], align: 'right' })
-          } else {
-            ui.div()
-          }
-        })
-    
-        ui.div()
-      }      
-    
-      console.log(ui.toString())
-      yargs.showHelp()
+    if (Object.prototype.hasOwnProperty.call(argv, '_') && argv._.length === 0 && invalidCommands.length === 0 && invalidArguments.length === 0) {
+        const ui = require('cliui')({
+            width: null,
+            wrap: null
+        });
+        if (registeredCommandObjs.length) {
+            ui.div('Commands:');
+            
+            const context = yargs.getContext();
+            const parentCommands = context.commands.length ? `${context.commands.join(' ')} ` : '';
+            
+            if (yargs.getParserConfiguration()['sort-commands'] === true) {
+                registeredCommandObjs = registeredCommandObjs.sort((a, b) => a[0].localeCompare(b[0]));
+            }
+            
+            registeredCommandObjs.forEach((command) => {
+                const commandString = `near ${parentCommands}${command.command.replace(/^\$0 ?/, '')}`; // drop $0 from default commands.
+                ui.span(
+                    {
+                        text: commandString,
+                        padding: [0, 2, 0, 2],
+                        width: maxWidth(registeredCommandObjs, null, `near${parentCommands}`) + 4
+                    },
+                    { text: command['desc'] }
+                );
+                const hints = [];
+                if (command[2]) hints.push(`[${'default:'.slice(0, -1)}]`);
+                if (command[3] && command[3].length) {
+                    hints.push(`[${'aliases:'} ${command[3].join(', ')}]`);
+                }
+                if (hints.length) {
+                    ui.div({ text: hints.join(' '), padding: [0, 0, 0, 2], align: 'right' });
+                } else {
+                    ui.div();
+                }
+            });
+            
+            ui.div();
+        }      
+        
+        console.log(ui.toString());
+        yargs.showHelp();
     }
 };

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ ncp.limit = 16;
 const rimraf = require('rimraf');
 const readline = require('readline');
 const URL = require('url').URL;
+const stringWidth = require('string-width')
 
 const { KeyPair, utils } = require('nearlib');
 
@@ -122,18 +123,93 @@ exports.stake = async function(options) {
     console.log(inspectResponse(result));
 };
 
-exports.defaultCommand = async function(options) {
-    let unclearPiece = `'${options._.join(', ')}'`;
-    switch (options._.length) {
-    case 0:
-        unclearPiece = 'argument(s)';
-        break;
-    case 1:
-        unclearPiece = `'${options._}'`;
-        break;
-    default:
-        // use initialized value
-        break;
+exports.checkCommandsArgs = async function (argv, yargs, registeredCommandObjs, registeredCommands) {
+    // logic borrowed from yargs/lib/usage.js
+    function maxWidth (table, theWrap, modifier) {
+        let width = 0
+        if (!Array.isArray(table)) {
+          table = Object.keys(table).map(key => [table[key]])
+        }
+        
+        table.forEach((v) => {
+          width = Math.max(
+            stringWidth(modifier ? `${modifier} ${v['command']}` : v['command']),
+            width
+          )
+        })
+        
+        if (theWrap) width = Math.min(width, parseInt(theWrap * 0.5, 10))
+        
+        return width
     }
-    console.warn(`Sorry, I do not understand ${unclearPiece}\nPlease run 'near' to see the list of available commands.`);
+
+    // find and inform user of invalid commands
+    const invalidCommands = argv._.filter(command => !registeredCommands.includes(command))
+    if (invalidCommands.length === 1) {
+        console.log(`Invalid command '${invalidCommands}'`)
+    } else if (invalidCommands.length > 1) {
+        console.log(`Invalid commands '${invalidCommands.join(', ')}'`)
+    }
+    
+    // valid arguments as understood by the yargs instance
+    const activeArgs = Object.keys(argv)
+    const validArgs = Object.keys(yargs.parsed.aliases)
+    // add a handful of special keys for our use case
+    validArgs.push(...['_', '$0', 'keyStore', 'contractName', 'walletUrl'])
+    
+    const invalidArguments = activeArgs.filter(arg => !validArgs.includes(arg))
+    if (invalidArguments.length === 1) {
+        console.error(`Invalid argument '${invalidArguments[0]}'`)
+    } else if (invalidArguments.length > 1) {
+        console.error(`Invalid argument(s) '${invalidArguments.join(', ')}'`)
+    }    
+    
+    // exit yargs, otherwise it tries to continue throwing misleading errors
+    if (invalidArguments.length !== 0 || invalidCommands.length !== 0) yargs.exit()
+    
+    // command 'near' with no invalid arguments or invalid commands displays --help
+    // logic borrowed from yargs/lib/usage.js
+    if (argv.hasOwnProperty('_') && argv._.length === 0 && invalidCommands.length === 0 && invalidArguments.length === 0) {
+      const ui = require('cliui')({
+        width: null,
+        wrap: null
+      })
+      if (registeredCommandObjs.length) {
+        ui.div('Commands:')
+    
+        const context = yargs.getContext()
+        const parentCommands = context.commands.length ? `${context.commands.join(' ')} ` : ''
+    
+        if (yargs.getParserConfiguration()['sort-commands'] === true) {
+          commands = registeredCommandObjs.sort((a, b) => a[0].localeCompare(b[0]))
+        }
+    
+        registeredCommandObjs.forEach((command) => {
+          const commandString = `near ${parentCommands}${command.command.replace(/^\$0 ?/, '')}` // drop $0 from default commands.
+          ui.span(
+            {
+              text: commandString,
+              padding: [0, 2, 0, 2],
+              width: maxWidth(registeredCommandObjs, null, `near${parentCommands}`) + 4
+            },
+            { text: command['desc'] }
+          )
+          const hints = []
+          if (command[2]) hints.push(`[${'default:'.slice(0, -1)}]`) // TODO hacking around i18n here
+          if (command[3] && command[3].length) {
+            hints.push(`[${'aliases:'} ${command[3].join(', ')}]`)
+          }
+          if (hints.length) {
+            ui.div({ text: hints.join(' '), padding: [0, 0, 0, 2], align: 'right' })
+          } else {
+            ui.div()
+          }
+        })
+    
+        ui.div()
+      }      
+    
+      console.log(ui.toString())
+      yargs.showHelp()
+    }
 };

--- a/index.js
+++ b/index.js
@@ -125,15 +125,15 @@ exports.stake = async function(options) {
 exports.defaultCommand = async function(options) {
     let unclearPiece = `'${options._.join(', ')}'`;
     switch (options._.length) {
-        case 0:
-            unclearPiece = 'argument(s)'
-            break;
-        case 1:
-            unclearPiece = `'${options._}'`
-            break;
-        default:
-            // use initialized value
-            break;
+    case 0:
+        unclearPiece = 'argument(s)';
+        break;
+    case 1:
+        unclearPiece = `'${options._}'`;
+        break;
+    default:
+        // use initialized value
+        break;
     }
-    console.warn(`Sorry, I do not understand ${unclearPiece}\nPlease run 'near' to see the list of available commands.`)
-}
+    console.warn(`Sorry, I do not understand ${unclearPiece}\nPlease run 'near' to see the list of available commands.`);
+};

--- a/index.js
+++ b/index.js
@@ -121,3 +121,19 @@ exports.stake = async function(options) {
     const result = await account.stake(options.stakingKey, utils.format.parseNearAmount(options.amount));
     console.log(inspectResponse(result));
 };
+
+exports.defaultCommand = async function(options) {
+    let unclearPiece = `'${options._.join(', ')}'`;
+    switch (options._.length) {
+        case 0:
+            unclearPiece = 'argument(s)'
+            break;
+        case 1:
+            unclearPiece = `'${options._}'`
+            break;
+        default:
+            // use initialized value
+            break;
+    }
+    console.warn(`Sorry, I do not understand ${unclearPiece}\nPlease run 'near' to see the list of available commands.`)
+}

--- a/test/test_generate_key.sh
+++ b/test/test_generate_key.sh
@@ -1,10 +1,10 @@
 
 #!/bin/bash
 set -ex
-KEY_FILE=neardev/default/generate-key-test.json
+KEY_FILE=neardev/ci/generate-key-test.json
 rm -f "$KEY_FILE"
 
-RESULT=$(./bin/near generate-key generate-key-test --networkId default)
+RESULT=$(./bin/near generate-key generate-key-test --networkId ci)
 echo $RESULT
  
 if [[ ! -f "${KEY_FILE}" ]]; then
@@ -18,7 +18,7 @@ if [[ ! "$RESULT" =~ $EXPECTED ]]; then
     exit 1
 fi
 
-RESULT2=$(./bin/near generate-key generate-key-test --networkId default)
+RESULT2=$(./bin/near generate-key generate-key-test --networkId ci)
 echo $RESULT2
 
 EXPECTED2=".*Account has existing key pair with ed25519:.+ public key.*"


### PR DESCRIPTION
Regarding #259 
[Followed this](https://github.com/yargs/yargs/blob/master/docs/advanced.md#default-commands) from the yargs documentation.

Added a couple of cases where an argument, command, and multiple commands are entered an not understood. Provides end user with simple feedback and instructions.

<img width="403" alt="Screenshot 2020-02-03 11 52 01" src="https://user-images.githubusercontent.com/1042667/73663042-9997b700-467b-11ea-99ac-879913bb440e.png">

**Update**: please see comments below regarding evolved approach
