### PR TITLE
add yarg’s strict() to chain. add walletUrl, contractName as options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - 10
   - 12
 env:
   - NODE_ENV=ci

--- a/bin/near-cli.js
+++ b/bin/near-cli.js
@@ -183,7 +183,7 @@ yargs // eslint-disable-line
         hidden: true
     })
     .option('masterAccount', {
-        desc: 'Master account used when create new accounts',
+        desc: 'Master account used when creating new accounts',
         type: 'string',
         hidden: true
     })

--- a/bin/near-cli.js
+++ b/bin/near-cli.js
@@ -173,11 +173,12 @@ yargs // eslint-disable-line
     .option('walletUrl', {
         desc: 'Website for NEAR Wallet',
         type: 'string',
-        default: 'trythis'
+        hidden: true
     })
     .option('contractName', {
         desc: 'Account name of contract',
         type: 'string',
+        hidden: true      
     })
     .middleware(require('../middleware/key-store'))
     .command(require('../commands/create-account'))

--- a/bin/near-cli.js
+++ b/bin/near-cli.js
@@ -182,6 +182,11 @@ yargs // eslint-disable-line
         type: 'string',
         hidden: true
     })
+    .option('masterAccount', {
+      desc: 'Master account used when create new accounts',
+      type: 'string',
+      hidden: true
+    })
     .middleware(require('../middleware/print-options'))
     .middleware(require('../middleware/key-store'))
     .command(require('../commands/create-account'))

--- a/bin/near-cli.js
+++ b/bin/near-cli.js
@@ -183,9 +183,9 @@ yargs // eslint-disable-line
         hidden: true
     })
     .option('masterAccount', {
-      desc: 'Master account used when create new accounts',
-      type: 'string',
-      hidden: true
+        desc: 'Master account used when create new accounts',
+        type: 'string',
+        hidden: true
     })
     .middleware(require('../middleware/print-options'))
     .middleware(require('../middleware/key-store'))

--- a/bin/near-cli.js
+++ b/bin/near-cli.js
@@ -145,6 +145,7 @@ const clean = {
 
 let config = require('../get-config')();
 yargs // eslint-disable-line
+    .strict()
     .middleware(require('../utils/check-version'))
     .scriptName('near')
     .option('nodeUrl', {
@@ -167,6 +168,15 @@ yargs // eslint-disable-line
     })
     .option('accountId', {
         desc: 'Unique identifier for the account',
+        type: 'string',
+    })
+    .option('walletUrl', {
+        desc: 'Website for NEAR Wallet',
+        type: 'string',
+        default: 'trythis'
+    })
+    .option('contractName', {
+        desc: 'Account name of contract',
         type: 'string',
     })
     .middleware(require('../middleware/key-store'))
@@ -197,5 +207,6 @@ yargs // eslint-disable-line
     })
     .showHelpOnFail(true)
     .demandCommand(1, 'Please enter a command')
+    .recommendCommands()
     .wrap(null)
     .argv;

--- a/test/test_account_operations.sh
+++ b/test/test_account_operations.sh
@@ -17,4 +17,4 @@ if [[ ! "$RESULT" =~ $EXPECTED ]]; then
     exit 1
 fi
 
-../bin/near delete_account $testaccount test.near
+../bin/near delete $testaccount test.near

--- a/test/test_generate_key.sh
+++ b/test/test_generate_key.sh
@@ -1,10 +1,10 @@
 
 #!/bin/bash
 set -ex
-KEY_FILE=neardev/ci/generate-key-test.json
+KEY_FILE=neardev/$NODE_ENV/generate-key-test.json
 rm -f "$KEY_FILE"
 
-RESULT=$(./bin/near generate-key generate-key-test --networkId ci)
+RESULT=$(./bin/near generate-key generate-key-test --networkId $NODE_ENV)
 echo $RESULT
  
 if [[ ! -f "${KEY_FILE}" ]]; then
@@ -18,7 +18,7 @@ if [[ ! "$RESULT" =~ $EXPECTED ]]; then
     exit 1
 fi
 
-RESULT2=$(./bin/near generate-key generate-key-test --networkId ci)
+RESULT2=$(./bin/near generate-key generate-key-test --networkId $NODE_ENV)
 echo $RESULT2
 
 EXPECTED2=".*Account has existing key pair with ed25519:.+ public key.*"

--- a/test/test_generate_key.sh
+++ b/test/test_generate_key.sh
@@ -1,10 +1,10 @@
 
 #!/bin/bash
 set -ex
-KEY_FILE=neardev/default/generate-key-test.json
+KEY_FILE=neardev/ci/generate-key-test.json
 rm -f "$KEY_FILE"
 
-RESULT=$(./bin/near generate-key generate-key-test --networkId default)
+RESULT=$(./bin/near generate-key generate-key-test --networkId ci)
 echo $RESULT
  
 if [[ ! -f "${KEY_FILE}" ]]; then
@@ -18,7 +18,7 @@ if [[ ! "$RESULT" =~ $EXPECTED ]]; then
     exit 1
 fi
 
-RESULT2=$(./bin/near generate-key generate-key-test --networkId default)
+RESULT2=$(./bin/near generate-key generate-key-test --networkId ci)
 echo $RESULT2
 
 EXPECTED2=".*Account has existing key pair with ed25519:.+ public key.*"


### PR DESCRIPTION
Different approach to https://github.com/nearprotocol/near-shell/issues/259
Also enabled recommendations. So `near fake` will fail, list possible commands, and say, "Did you mean `near stake`?"
I think the issue was `.config(config)` loaded `src/config.js` which has keys that weren't explicitly set as `option`s.

~This is quite separate from the PR where most of the discussion on this issue has been happening.~
https://github.com/nearprotocol/near-shell/pull/262

If we choose to merge this PR, we can close the other.

Update: this PR has been languishing and Illia brought up that this is important. I see that @vgrichina suggests we overhaul how config is used. Can we get something done in the meantime?

Tests have been failing and I have commits fixing these, including some outdated shell commands. Kind of mysterious that tests have worked at all. I guess some errant calls technically don't `exit(1)`? Doesn't matter too much, this is ready for re-review.