### PR TITLE
gulp on windows needs shell key during spawn()

### DIFF
--- a/bin/near-cli.js
+++ b/bin/near-cli.js
@@ -118,7 +118,7 @@ const build = {
     command: 'build',
     desc: 'build your smart contract',
     handler: () => {
-        const gulp = spawn('gulp');
+        const gulp = spawn('gulp', [], {shell: process.platform == 'win32'});
         gulp.stdout.on('data', function (data) {
             console.log(data.toString());
         });


### PR DESCRIPTION
In testing examples on a Windows machine, I noticed that `near build` will not work.

`Error: spawn gulp ENOENT`

I eventually found this [StackOverflow answer](https://stackoverflow.com/a/54515183). Tested on Windows and Mac.