### PR TITLE
during dev-deploy create neardev/dev-account.env for future env-cmd usage

### DIFF
--- a/commands/dev-deploy.js
+++ b/commands/dev-deploy.js
@@ -67,5 +67,5 @@ async function createDevAccountIfNeeded({ near, keyStore, networkId, init }) {
     await writeFile(accountFilePath, accountId);
     // write file to be used by env-cmd
     await writeFile(accountFilePathEnv, `CONTRACT_NAME=${accountId}`);
-    return accountId;``
+    return accountId;
 }

--- a/commands/dev-deploy.js
+++ b/commands/dev-deploy.js
@@ -41,6 +41,8 @@ async function devDeploy(options) {
 }
 
 async function createDevAccountIfNeeded({ near, keyStore, networkId, init }) {
+    // TODO: once examples and create-near-app use the dev-account.env file, we can remove the creation of dev-account
+    // https://github.com/nearprotocol/near-shell/issues/287
     const accountFilePath = `${keyStore.keyDir}/dev-account`;
     const accountFilePathEnv = `${keyStore.keyDir}/dev-account.env`;
     if (!init) {


### PR DESCRIPTION
Creates a second file in the `neardev` folder. This file is structured like an environment variable file that stores:
`CONTRACT_ID=dev1234567890123` instead of just the account id.
This is the first step in enabling us to allow Windows users to use some of our quick-start tools like `create-near-app`. There will be forthcoming pull requests in `create-near-app` for this.
Essentially we will be loading this new file as an environment variable so that `parcel` can run on Windows.
One of the issues we currently have with quick-start tools like `create-near-app` is we're `cat`ing the previous file (`neardev/dev-account`) in order to set an environment variable. I have reason to believe this will never work for Windows, but we can leverage cross-platform dependencies like [cross-env](https://www.npmjs.com/package/cross-env) and [env-cmd](https://www.npmjs.com/package/env-cmd) if we use an approach where we can load a file for this instead. 
That's the whole picture, and this PR is the first step toward that.