### PR TITLE
Set initialBalance to 100N in create_account

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - 10
   - 12
 env:
   - NODE_ENV=ci

--- a/bin/near-cli.js
+++ b/bin/near-cli.js
@@ -146,6 +146,7 @@ const clean = {
 
 let config = require('../get-config')();
 yargs // eslint-disable-line
+    .strict()
     .middleware(require('../utils/check-version'))
     .scriptName('near')
     .option('nodeUrl', {
@@ -169,6 +170,22 @@ yargs // eslint-disable-line
     .option('accountId', {
         desc: 'Unique identifier for the account',
         type: 'string',
+    })
+
+    .option('walletUrl', {
+        desc: 'Website for NEAR Wallet',
+        type: 'string',
+        hidden: true
+    })
+    .option('contractName', {
+        desc: 'Account name of contract',
+        type: 'string',
+        hidden: true
+    })
+    .option('masterAccount', {
+        desc: 'Master account used when creating new accounts',
+        type: 'string',
+        hidden: true
     })
     .middleware(require('../middleware/print-options'))
     .middleware(require('../middleware/key-store'))
@@ -198,6 +215,7 @@ yargs // eslint-disable-line
         'outDir': 'out_dir'
     })
     .showHelpOnFail(true)
+    .recommendCommands()
     .demandCommand(1, chalk`Pass {bold --help} to see all available commands and options.`)
     .usage(chalk`Usage: {bold $0 <command> [options]}`)
     .epilogue(chalk`Check out our epic whiteboard series: {bold http://near.ai/wbs}`)

--- a/commands/create-account.js
+++ b/commands/create-account.js
@@ -25,7 +25,7 @@ module.exports = {
         .option('initialBalance', {
             desc: 'Number of tokens to transfer to newly created account',
             type: 'string',
-            default: '0.1'
+            default: '100'
         }),
     handler: exitOnError(createAccount)
 };

--- a/test/test_account_operations.sh
+++ b/test/test_account_operations.sh
@@ -11,7 +11,7 @@ echo Create account
 echo Get account state
 RESULT=$(../bin/near state $testaccount | strip-ansi)
 echo $RESULT
-EXPECTED=".+Account $testaccount.+amount:.+'100000000000000000000000'.+ "
+EXPECTED=".+Account $testaccount.+amount:.+'100000000000000000000000000'.+ "
 if [[ ! "$RESULT" =~ $EXPECTED ]]; then
     echo FAILURE Unexpected output from near view
     exit 1

--- a/test/test_account_operations.sh
+++ b/test/test_account_operations.sh
@@ -17,4 +17,4 @@ if [[ ! "$RESULT" =~ $EXPECTED ]]; then
     exit 1
 fi
 
-../bin/near delete_account $testaccount test.near
+../bin/near delete $testaccount test.near

--- a/test/test_generate_key.sh
+++ b/test/test_generate_key.sh
@@ -1,10 +1,10 @@
 
 #!/bin/bash
 set -ex
-KEY_FILE=neardev/default/generate-key-test.json
+KEY_FILE=neardev/$NODE_ENV/generate-key-test.json
 rm -f "$KEY_FILE"
 
-RESULT=$(./bin/near generate-key generate-key-test --networkId default)
+RESULT=$(./bin/near generate-key generate-key-test --networkId $NODE_ENV)
 echo $RESULT
  
 if [[ ! -f "${KEY_FILE}" ]]; then
@@ -18,7 +18,7 @@ if [[ ! "$RESULT" =~ $EXPECTED ]]; then
     exit 1
 fi
 
-RESULT2=$(./bin/near generate-key generate-key-test --networkId default)
+RESULT2=$(./bin/near generate-key generate-key-test --networkId $NODE_ENV)
 echo $RESULT2
 
 EXPECTED2=".*Account has existing key pair with ed25519:.+ public key.*"


### PR DESCRIPTION
After state staking update https://github.com/nearprotocol/NEPs/pull/41, 1N covers for 10kb of storage. 
So 100N covers 1MB storage which should be enough for initial playing with contracts.
Current 0.1N leads to LackBalance error.