### PR TITLE
Addresses subdomains in create_account, dev-deploy

### DIFF
--- a/commands/create-account.js
+++ b/commands/create-account.js
@@ -8,7 +8,6 @@ const NEAR_ENV_SUFFIXES = [
     'dev'
 ];
 const TLA_MIN_LENGTH = 11;
-const ERROR_INVALID_FORMAT = new Error('Invalid format for account name, please check console for details.');
 
 module.exports = {
     command: 'create_account <accountId>',
@@ -45,19 +44,19 @@ async function createAccount(options) {
         // TLA (bob-at-least-maximum-chars.test)
         if (splitAccount[0].length < TLA_MIN_LENGTH) {
             console.log(`Top-level accounts (not ending in .near, .test, etc) must be greater than ${TLA_MIN_LENGTH} characters`);
-            throw(ERROR_INVALID_FORMAT);
+            return;
         }
     } else if (splitAccount.length === 3) {
         // Subdomain (short.alice.near)
         if (!NEAR_ENV_SUFFIXES.includes(splitAccount[2])) {
             console.log(`Expected a subdomain account name ending in ${NEAR_ENV_SUFFIXES.join(', ')}. (Example: counter.alice.test)`);
-            throw(ERROR_INVALID_FORMAT);
+            return;
         }
     } else {
         console.log('Unexpected account name format. Please use one of these formats:\n' +
         `1. Top-level name with ${TLA_MIN_LENGTH}+ characters (ex: near-friend.test)\n` +
         `2. A subdomain account name ending with .${NEAR_ENV_SUFFIXES.join(', .')}. (Example: counter.alice.test)`);
-        throw(ERROR_INVALID_FORMAT);
+        return;
     }
     let near = await connect(options);
     let keyPair;

--- a/commands/create-account.js
+++ b/commands/create-account.js
@@ -2,13 +2,13 @@ const exitOnError = require('../utils/exit-on-error');
 const connect = require('../utils/connect');
 const { KeyPair } = require('near-api-js');
 const NEAR_ENV_SUFFIXES = [
-  'near',
-  'test',
-  'beta',
-  'dev'
+    'near',
+    'test',
+    'beta',
+    'dev'
 ];
 const TLA_MIN_LENGTH = 11;
-const ERROR_INVALID_FORMAT = new Error("Invalid format for account name, please check console for details.")
+const ERROR_INVALID_FORMAT = new Error('Invalid format for account name, please check console for details.');
 
 module.exports = {
     command: 'create_account <accountId>',
@@ -54,7 +54,7 @@ async function createAccount(options) {
             throw(ERROR_INVALID_FORMAT);
         }
     } else {
-        console.log(`Unexpected account name format. Please use one of these formats:\n` +
+        console.log('Unexpected account name format. Please use one of these formats:\n' +
         `1. Top-level name with ${TLA_MIN_LENGTH}+ characters (ex: near-friend.test)\n` +
         `2. A subdomain account name ending with .${NEAR_ENV_SUFFIXES.join(', .')}. (Example: counter.alice.test)`);
         throw(ERROR_INVALID_FORMAT);

--- a/commands/create-account.js
+++ b/commands/create-account.js
@@ -1,17 +1,18 @@
 const exitOnError = require('../utils/exit-on-error');
 const connect = require('../utils/connect');
 const { KeyPair } = require('near-api-js');
-const NEAR_ENV_SUFFIXES = [
-    'near',
-    'test',
-    'beta',
-    'dev'
-];
-const TLA_MIN_LENGTH = 11;
+const NEAR_ENV_SUFFIXES = {
+    production: 'near',
+    default: 'test',
+    development: 'test',
+    devnet: 'dev',
+    betanet: 'beta'
+};
+const TLA_MIN_LENGTH = 32;
 
 module.exports = {
     command: 'create_account <accountId>',
-    desc: 'create a new developer account (top-level account 11+ chars, or a subdomain of the masterAccount)',
+    desc: 'create a new developer account (subaccount of the masterAccount, ex: app.alice.test)',
     builder: (yargs) => yargs
         .option('accountId', {
             desc: 'Unique identifier for the newly created account',
@@ -38,25 +39,38 @@ module.exports = {
 
 async function createAccount(options) {
     // NOTE: initialBalance is passed as part of config here, parsed in middleware/initial-balance
-    // periods are disallowed in top-level accounts and can only be used for subdomains
+    // periods are disallowed in top-level accounts and can only be used for subaccounts
     const splitAccount = options.accountId.split('.');
-    if (splitAccount.length === 2) {
-        // TLA (bob-at-least-maximum-chars.test)
+
+    const splitMaster = options.masterAccount.split('.');
+    const masterRootTLA = splitMaster[splitMaster.length - 1];
+    if (splitAccount.length === 1) {
+        // TLA (bob-with-at-least-maximum-characters)
         if (splitAccount[0].length < TLA_MIN_LENGTH) {
-            console.log(`Top-level accounts (not ending in .near, .test, etc) must be greater than ${TLA_MIN_LENGTH} characters`);
+            console.log(`Top-level accounts must be greater than ${TLA_MIN_LENGTH} characters.\n` +
+              'Note: this is for advanced usage only. Typical account names are of the form:\n' +
+              'app.alice.test, where the masterAccount shares the top-level account (.test).'
+            );
             return;
         }
-    } else if (splitAccount.length === 3) {
-        // Subdomain (short.alice.near)
-        if (!NEAR_ENV_SUFFIXES.includes(splitAccount[2])) {
-            console.log(`Expected a subdomain account name ending in ${NEAR_ENV_SUFFIXES.join(', ')}. (Example: counter.alice.test)`);
+    } else if (splitAccount.length > 1) {
+        // Subaccounts (short.alice.near, even.more.bob.test, and eventually peter.potato)
+        // Check that master account TLA matches
+        const accountRootTLA = splitAccount[splitAccount.length - 1];
+        const accountTLA = splitAccount.filter((n, i) => i !== 0).join('.');
+        if (accountTLA !== options.masterAccount) {
+            console.log(`New account doesn't share the same top-level account. Expecting account name to end in ".${options.masterAccount}"`);
             return;
         }
-    } else {
-        console.log('Unexpected account name format. Please use one of these formats:\n' +
-        `1. Top-level name with ${TLA_MIN_LENGTH}+ characters (ex: near-friend.test)\n` +
-        `2. A subdomain account name ending with .${NEAR_ENV_SUFFIXES.join(', .')}. (Example: counter.alice.test)`);
-        return;
+
+        // Rules apply for environments except local, test, ci, ci-staging
+        if (Object.keys(NEAR_ENV_SUFFIXES).includes(options.networkId)) {
+            // Recommend that the TLA matches the expected network in most cases
+            const networkTLA = NEAR_ENV_SUFFIXES[options.networkId];
+            if (networkTLA !== masterRootTLA || networkTLA !== accountRootTLA) {
+                console.log(`NOTE: In most cases, when connected to "${options.networkId}" account and masterAccount will end in ".${networkTLA}"`);
+            }
+        }
     }
     let near = await connect(options);
     let keyPair;

--- a/commands/dev-deploy.js
+++ b/commands/dev-deploy.js
@@ -62,7 +62,7 @@ async function createDevAccountIfNeeded({ near, keyStore, networkId, init }) {
         }
     }
 
-    const accountId = `dev-${Date.now()}`;
+    const accountId = `dev-${Date.now()}.test.near`;
     const keyPair = await KeyPair.fromRandom('ed25519');
     await near.accountCreator.createAccount(accountId, keyPair.publicKey);
     await keyStore.setKey(networkId, accountId, keyPair);

--- a/commands/dev-deploy.js
+++ b/commands/dev-deploy.js
@@ -45,7 +45,7 @@ async function devDeploy(options) {
     console.log(`Done deploying to ${accountId}`);
 }
 
-async function createDevAccountIfNeeded({ near, keyStore, networkId, init }) {
+async function createDevAccountIfNeeded({ near, keyStore, networkId, init, masterAccount }) {
     // TODO: once examples and create-near-app use the dev-account.env file, we can remove the creation of dev-account
     // https://github.com/nearprotocol/near-shell/issues/287
     const accountFilePath = `${keyStore.keyDir}/dev-account`;
@@ -67,7 +67,7 @@ async function createDevAccountIfNeeded({ near, keyStore, networkId, init }) {
         }
     }
 
-    const accountId = `dev-${Date.now()}.test.near`;
+    const accountId = `dev-${Date.now()}.${masterAccount}`;
     const keyPair = await KeyPair.fromRandom('ed25519');
     await near.accountCreator.createAccount(accountId, keyPair.publicKey);
     await keyStore.setKey(networkId, accountId, keyPair);

--- a/test/test_account_operations.sh
+++ b/test/test_account_operations.sh
@@ -4,12 +4,12 @@ rm  -rf tmp-project
 yarn create near-app --vanilla tmp-project
 cd tmp-project
 timestamp=$(date +%s)
-testaccount=testaccount$timestamp
+testaccount=testaccount$timestamp.test.near
 echo Create account
 ../bin/near create_account $testaccount
 
 echo Get account state
-RESULT=$(../bin/near state $testaccount | strip-ansi)
+RESULT=$(../bin/near state $testaccount | ../node_modules/.bin/strip-ansi)
 echo $RESULT
 EXPECTED=".+Account $testaccount.+amount:.+'100000000000000000000000000'.+ "
 if [[ ! "$RESULT" =~ $EXPECTED ]]; then

--- a/test/test_contract.sh
+++ b/test/test_contract.sh
@@ -7,7 +7,7 @@ yarn create near-app --vanilla tmp-project
 cd tmp-project
 
 timestamp=$(date +%s)
-testaccount=testaccount$timestamp
+testaccount=testaccount$timestamp.test.near
 ../bin/near create_account $testaccount
 
 echo Building contract


### PR DESCRIPTION
Addresses https://github.com/nearprotocol/near-shell/issues/307.
Note that there is still an underlying issue when the test tries to deploy a contract:
```
Error:  LackBalanceForState [Error]: The account dev-1587603497974.test.near wouldn't have enough balance to cover storage, required to have 16543700000000000000000
    at Object.parseRpcError (/Users/mike/near/near-shell/node_modules/near-api-js/lib/utils/rpc_errors.js:25:19)
    at Account.signAndSendTransaction (/Users/mike/near/near-shell/node_modules/near-api-js/lib/account.js:114:36)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
    at async LocalAccountCreator.createAccount (/Users/mike/near/near-shell/node_modules/near-api-js/lib/account_creator.js:23:9)
    at async createDevAccountIfNeeded (/Users/mike/near/near-shell/commands/dev-deploy.js:67:5)
    at async devDeploy (/Users/mike/near/near-shell/commands/dev-deploy.js:34:23)
    at async Object.handler (/Users/mike/near/near-shell/utils/exit-on-error.js:4:9) {
  type: 'LackBalanceForState',
  index: null,
  amount: '16543700000000000000000',
  signer_id: undefined,
  account_id: 'dev-1587603497974.test.near'
```
Edit: resolved, see Vlad's comment below.

Edit2:
This ended up being a bit of a compromise, knowing that long-term, we'll be allowing TLA's that are based on other chains' account addresses. Yet at the same time, we want to make clear to the end user that **most** of the time they'll want to approach account creation as subaccounts.

Here's a list of commands run and the results to demonstrate:
`./bin/near create_account hihihi --masterAccount asdf.test`
results in:

> Top-level accounts must be greater than 32 characters.
> Note: this is for advanced usage only. Typical account names are of the form:
> app.alice.test, where the masterAccount shares the top-level account (.test).
> 

`./bin/near create_account hihihiveryveryverylongnamethisisunusual --masterAccount asdf.test`
passes

`NODE_ENV=betanet ./bin/near create_account mike.asdf.test --masterAccount asdf.test`
passes but throws the message:

> NOTE: In most cases, when connected to "betanet", account and masterAccount will end in ".beta"

`./bin/near create_account mike.asdf.test --masterAccount asdf.test`
succeeds

`./bin/near create_account hi.mike.asdf.test --masterAccount mike.asdf.test`
succeeds

`./bin/near create_account hi.mike.asdf.test --masterAccount mike.asdf.purvis`
results in:

>New account doesn't share the same top-level account. Expecting account name to end in ".mike.asdf.purvis"

`./bin/near create_account hi.mike.asdf.purvis --masterAccount mike.asdf.test`
results in:

>New account doesn't share the same top-level account. Expecting account name to end in ".mike.asdf.test"

<a href="https://gitpod.io/#https://github.com/nearprotocol/near-shell/pull/324"><img src="https://gitpod.io/api/apps/github/pbs/github.com/nearprotocol/near-shell.git/9e217cc684d567e1edb2cd57f2dedfc3a187fd89.svg" /></a>

