### PR TITLE
Hotfix/307 subdomains

### DIFF
--- a/commands/dev-deploy.js
+++ b/commands/dev-deploy.js
@@ -48,7 +48,7 @@ async function devDeploy(options) {
     await eventtracking.track(eventtracking.EVENT_ID_DEV_DEPLOY_END, { node: options.nodeUrl, success: true });
 }
 
-async function createDevAccountIfNeeded({ near, keyStore, networkId, init, masterAccount }) {
+async function createDevAccountIfNeeded({ near, keyStore, networkId, init, masterAccount, helperUrl }) {
     // TODO: once examples and create-near-app use the dev-account.env file, we can remove the creation of dev-account
     // https://github.com/nearprotocol/near-shell/issues/287
     const accountFilePath = `${keyStore.keyDir}/dev-account`;
@@ -70,7 +70,15 @@ async function createDevAccountIfNeeded({ near, keyStore, networkId, init, maste
         }
     }
 
-    const accountId = `dev-${Date.now()}.${masterAccount}`;
+    let accountId;
+    if (typeof masterAccount === "undefined" && helperUrl) {
+        // determine "faucet" account name of environment from helperUrl
+        const splitHelper = helperUrl.split('.');
+        accountId = `dev-${Date.now()}.${splitHelper[1]}`;
+    } else {
+        accountId = `dev-${Date.now()}.${masterAccount}`;
+    }
+    
     const keyPair = await KeyPair.fromRandom('ed25519');
     await near.accountCreator.createAccount(accountId, keyPair.publicKey);
     await keyStore.setKey(networkId, accountId, keyPair);

--- a/commands/dev-deploy.js
+++ b/commands/dev-deploy.js
@@ -71,7 +71,7 @@ async function createDevAccountIfNeeded({ near, keyStore, networkId, init, maste
     }
 
     let accountId;
-    if (typeof masterAccount === "undefined" && helperUrl) {
+    if (typeof masterAccount === 'undefined' && helperUrl) {
         // determine "faucet" account name of environment from helperUrl
         const splitHelper = helperUrl.split('.');
         accountId = `dev-${Date.now()}.${splitHelper[1]}`;


### PR DESCRIPTION
Second attempt at issue:
https://github.com/nearprotocol/near-shell/issues/307

First attempt was here:
https://github.com/nearprotocol/near-shell/pull/324

It was my mistake in not testing it properly and we reverted that PR.

The new item here is during dev-deploy, we check to see what environment the user is on (betanet, testnet, etc) and if it's using a `helperUrl` determine what the name of the account is that'll be funding the creation. So we split the `helperUrl`. Basically a newly created account can either be from a `masterAccount` or from a `helperUrl` and we need to determine what the account suffix will be.

With the latest commit this kind of thing will work, when before it would fail:
`NODE_ENV=ci yarn near dev-deploy`
^ Note: I ran this in the `guest-book` example after I copy/pasted shell's `config.js` to guest-book's `src/config.js` so it knows about betanet and the new URLs.

So above is the new stuff.
I'll paste the description from the other PR, which is the old stuff:
This ended up being a bit of a compromise, knowing that long-term, we'll be allowing TLA's that are based on other chains' account addresses. Yet at the same time, we want to make clear to the end user that **most** of the time they'll want to approach account creation as subaccounts.

Here's a list of commands run and the results to demonstrate:
`./bin/near create_account hihihi --masterAccount asdf.test`
results in:

> Top-level accounts must be greater than 32 characters.
> Note: this is for advanced usage only. Typical account names are of the form:
> app.alice.test, where the masterAccount shares the top-level account (.test).
> 

`./bin/near create_account hihihiveryveryverylongnamethisisunusual --masterAccount asdf.test`
passes

`NODE_ENV=betanet ./bin/near create_account mike.asdf.test --masterAccount asdf.test`
passes but throws the message:

> NOTE: In most cases, when connected to "betanet", account and masterAccount will end in ".beta"

`./bin/near create_account mike.asdf.test --masterAccount asdf.test`
succeeds

`./bin/near create_account hi.mike.asdf.test --masterAccount mike.asdf.test`
succeeds

`./bin/near create_account hi.mike.asdf.test --masterAccount mike.asdf.purvis`
results in:

>New account doesn't share the same top-level account. Expecting account name to end in ".mike.asdf.purvis"

`./bin/near create_account hi.mike.asdf.purvis --masterAccount mike.asdf.test`
results in:

>New account doesn't share the same top-level account. Expecting account name to end in ".mike.asdf.test"

<a href="https://gitpod.io/#https://github.com/nearprotocol/near-shell/pull/331"><img src="https://gitpod.io/api/apps/github/pbs/github.com/nearprotocol/near-shell.git/41b2c6773354e5037c4e1ca17ebec238242783ad.svg" /></a>

