### PR TITLE
Default gas fix

### DIFF
--- a/commands/call.js
+++ b/commands/call.js
@@ -11,7 +11,7 @@ module.exports = {
         .option('gas', {
             desc: 'Max amount of gas this call can use (in gas units)',
             type: 'string',
-            default: DEFAULT_FUNCTION_CALL_GAS
+            default: DEFAULT_FUNCTION_CALL_GAS.toNumber(),
         })
         .option('deposit', {
             desc: 'Number of tokens to attach (in NEAR) to a function call',


### PR DESCRIPTION
Before: 
```bash
--gas    Max amount of gas this call can use (in gas units)  [string] [default: "1b48eb57e000"]

```
After:
```bash
--gas    Max amount of gas this call can use (in gas units)  [string] [default: 30000000000000]
```