### PR TITLE
bump near-api-js version

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "jest-environment-node": "^27.0.6",
     "mixpanel": "^0.13.0",
     "ncp": "^2.0.0",
-    "near-api-js": "^0.42.0",
+    "near-api-js": "^0.43.1",
     "near-seed-phrase": "^0.2.0",
     "open": "^8.0.7",
     "rimraf": "^3.0.0",


### PR DESCRIPTION
the new version handled the `Expired` error, which is causing lots of frustrations right now.