### PR TITLE
Gas exceeded error is handled

### DIFF
--- a/commands/call.js
+++ b/commands/call.js
@@ -52,7 +52,7 @@ async function scheduleFunctionCall(options) {
     const near = await connect(options);
     const account = await near.account(options.accountId);
     const parsedArgs = options.base64 ? Buffer.from(options.args, 'base64') : JSON.parse(options.args || '{}');
-    console.log("Doing account.functionCall()");
+    console.log('Doing account.functionCall()');
     try {
         const functionCallResponse = await account.functionCall({
             contractId: options.contractName,
@@ -66,18 +66,18 @@ async function scheduleFunctionCall(options) {
         console.log(inspectResponse.formatResponse(result));
     } catch (error) {
         switch (JSON.stringify(error.kind)) {
-            case '{"ExecutionError":"Exceeded the prepaid gas."}': {
-                handleExceededThePrepaidGasError(error, options);
-                break;
-            }
-            default: {
-                console.log(error);
-            }
+        case '{"ExecutionError":"Exceeded the prepaid gas."}': {
+            handleExceededThePrepaidGasError(error, options);
+            break;
+        }
+        default: {
+            console.log(error);
+        }
         }
     }
 }
 
 function handleExceededThePrepaidGasError(error, options) {
     console.log(chalk.bold(`\nTransaction ${error.transaction_outcome.id} had ${options.gas} of attached gas but used ${error.transaction_outcome.outcome.gas_burnt} of gas`));
-    console.log("View this transaction in explorer:", chalk.blue(`https://explorer.${options.networkId}.near.org/transactions/${error.transaction_outcome.id}`));
+    console.log('View this transaction in explorer:', chalk.blue(`https://explorer.${options.networkId}.near.org/transactions/${error.transaction_outcome.id}`));
 }


### PR DESCRIPTION
Output after this fix:

```bash
serhii@pc ~/P/N/near-cli (gas-error-fix)> ./bin/near call ft.demo.testnet storage_deposit '' --accountId volovyk2.testnet --amount 0.125 --gas=1
Scheduling a call: ft.demo.testnet.storage_deposit() with attached 0.125 NEAR
Doing account.functionCall()
Receipts: DxYETG3j5tog5We9NaKiG8XxcRscSeqTP1tgtPefaE1H, 8LwVTWn2o2eRGtoLMZ1PXiK8djAuRuAzV7RmxNhxHRAG
	Failure [ft.demo.testnet]: Error: {"index":0,"kind":{"ExecutionError":"Exceeded the prepaid gas."}}

Transaction CB1e8RRSVRqdzW4v1uVmh99BMfQfXyzEhMaqbZPcEKeM had 1 of attached gas but used 2427959010878 of gas
View this transaction in explorer: https://explorer.testnet.near.org/transactions/CB1e8RRSVRqdzW4v1uVmh99BMfQfXyzEhMaqbZPcEKeM

```